### PR TITLE
MySQLInstaller : ne vérifier le réseau qu'en mode Create (déblocage hors-ligne)

### DIFF
--- a/MySQLInstaller/mysqlinstaller.cpp
+++ b/MySQLInstaller/mysqlinstaller.cpp
@@ -783,16 +783,15 @@ bool MySQLInstaller::run()
     }
 #endif
 
-    // ── Accès réseau requis pour tout le programme ────────────────────────────
-    if (!hasNetworkAccess()) {
-        UpMessageBox::Watch(nullptr, tr("Pas d'accès réseau"),
-            tr("Absence d'accès réseau. Le programme a besoin d'une connexion "
-               "Internet pour fonctionner.\n\nFermeture du programme."));
-        return false;
-    }
+    // NB : on ne vérifie PAS l'accès réseau ici. Il n'est nécessaire que pour
+    // TÉLÉCHARGER MySQL (mode Create), et ce cas est déjà couvert par
+    // checkDownloadConnectivity() (appelé dans faireCreate(), qui appelle lui-même
+    // hasNetworkAccess()). Vérifier le réseau dès run() bloquerait inutilement un
+    // poste hors-ligne qui a DÉJÀ MySQL (mode Verify) ou une base Rufus complète.
 
     // Config distante (version cible + seuil minimal). La checklist affiche le
     // seuil dans le libellé de la case « MySQL ≥ <min> installé ».
+    // fetchRemoteConfig() se replie sur les valeurs par défaut si le réseau manque.
     const MySQLRemoteConfig cfg = fetchRemoteConfig();
 
     const bool installed = isMySQLInstalled();


### PR DESCRIPTION
Cosmétique / robustesse hors-ligne.

`MySQLInstaller::hasNetworkAccess()` était appelé en tête de `run()` et **bloquait le logiciel pour tout le monde** dès qu'il n'y avait pas d'accès Internet — y compris un poste **hors-ligne qui a déjà MySQL** (mode Verify) ou une base Rufus complète, qui n'ont aucun besoin de télécharger quoi que ce soit.

Le réseau n'est nécessaire **que pour télécharger MySQL** (mode Create), cas déjà couvert par `checkDownloadConnectivity()` (appelé dans `faireCreate()`, qui appelle lui-même `hasNetworkAccess()`). On retire donc la vérification redondante de `run()`. `fetchRemoteConfig()` se repliant déjà sur ses valeurs par défaut hors-ligne, le mode Verify fonctionne désormais sans accès réseau.

Vérifié : compile proprement (Qt6, syntaxe).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFVPrY9BEqWjvzkotspaXH)_