### PR TITLE
BaseExistante monoposte : sécurisation à la volée d'une base non sécurisée (gaxt78iy conservé en 2e mdp)

### DIFF
--- a/Dialogs/dlg_paramconnexion.cpp
+++ b/Dialogs/dlg_paramconnexion.cpp
@@ -226,6 +226,12 @@ bool dlg_paramconnexion::TestConnexion()
                                     + error);
             return false;
         }
+        //! Connexion MONOPOSTE réussie : si la base est encore sur le mot de passe
+        //! public (pas de .dbkey), on la sécurise à la volée — un mot de passe
+        //! aléatoire est posé tout en CONSERVANT gaxt78iy comme 2e mot de passe, pour
+        //! ne bloquer aucun autre poste si ce poste sert aussi de serveur. No-op si
+        //! la base est déjà sécurisée.
+        MySQLInstaller().securiserBaseSiNecessaire();
         if (m_connectavecloginSQL)
         {
             DataBase::QueryResult rep = DataBase::I()->verifExistUser(ui->LoginlineEdit->text(), ui->MDPlineEdit->text());

--- a/MySQLInstaller/mysqlinstaller.cpp
+++ b/MySQLInstaller/mysqlinstaller.cpp
@@ -1369,6 +1369,59 @@ QString MySQLInstaller::getMySQLVersion()
     return m.hasMatch() ? m.captured(1) : QString();
 }
 
+//  Sécurisation à la volée d'une base existante (monoposte). Cf. en-tête.
+void MySQLInstaller::securiserBaseSiNecessaire()
+{
+    // 1. Base déjà sécurisée (clé présente) → rien à faire.
+    if (QFile::exists(PATH_FILE_DBKEY))
+        return;
+
+    const QString legacy = QString(MDP_SQL);          // gaxt78iy (mot de passe public)
+
+    // 2. gaxt78iy fonctionne-t-il vraiment ? Sinon : base injoignable avec nos comptes
+    //    (ou base sécurisée dont le legacy a déjà été retiré) → on ne touche à rien.
+    if (!tryConnectAs(QString(LOGIN_SQL), legacy))
+        return;
+
+    // 3. Le serveur supporte-t-il le double mot de passe (RETAIN CURRENT PASSWORD) ?
+    //    Requiert MySQL >= 8.0.14 et PAS MariaDB. Sinon, rotater bloquerait les autres
+    //    postes → on laisse la base telle quelle (sécurisation explicite plus tard).
+    const QString sv = runCmdFull(
+        QString("\"%1\" " LOCAL_TCP_ARGS " -u \"%2\" -p\"%3\" -N -B -e "
+                "\"SELECT VERSION();\" 2>&1")
+            .arg(mysqlBin("mysql"), QString(LOGIN_SQL), legacy)).trimmed();
+    if (sv.contains("MariaDB", Qt::CaseInsensitive))
+        return;
+    QRegularExpression re(R"((\d+\.\d+\.\d+))");
+    const auto mv = re.match(sv);
+    if (!mv.hasMatch() || !versionAtLeast(mv.captured(1), "8.0.14"))
+        return;
+
+    // 4. Sécurisation : nouveau mot de passe aléatoire pour adminrufus/adminrufusSSL,
+    //    en CONSERVANT gaxt78iy comme 2e mot de passe (RETAIN CURRENT PASSWORD).
+    //    NB (cas connu, rare en monoposte) : si .dbkey a été supprimé À LA MAIN d'une
+    //    base DÉJÀ sécurisée, gaxt78iy y est un mot de passe SECONDAIRE ; re-sécuriser
+    //    le chasserait (MySQL ne garde qu'un seul mdp secondaire). À affiner plus tard.
+    const QString np       = genererMotDePasse();
+    const QString sslLogin = QString(LOGIN_SQL "SSL");
+    const QString sql = QString(
+        "ALTER USER '%1'@'%' IDENTIFIED BY '%2' RETAIN CURRENT PASSWORD;"
+        "CREATE USER IF NOT EXISTS '%3'@'%' IDENTIFIED BY '%4' REQUIRE SSL;"
+        "GRANT ALL PRIVILEGES ON *.* TO '%3'@'%' WITH GRANT OPTION;"
+        "ALTER USER '%3'@'%' IDENTIFIED BY '%2' RETAIN CURRENT PASSWORD;"
+        "FLUSH PRIVILEGES;")
+        .arg(QString(LOGIN_SQL), np, sslLogin, legacy);
+    const QString out = runCmdFull(
+        QString("\"%1\" " LOCAL_TCP_ARGS " -u \"%2\" -p\"%3\" -e \"%4\" 2>&1")
+            .arg(mysqlBin("mysql"), QString(LOGIN_SQL), legacy, sql));
+    if (out.contains("ERROR", Qt::CaseInsensitive))
+        return;   // échec : on NE stocke PAS .dbkey → la base reste sur gaxt78iy
+
+    // 5. Mémoriser le nouveau mot de passe : ce poste s'y connectera désormais ;
+    //    gaxt78iy reste valable pour les autres postes (2e mot de passe).
+    stockerMotDePasse(np);
+}
+
 QString MySQLInstaller::downloadOracleDmg()
 {
     const MySQLRemoteConfig cfg = fetchRemoteConfig();

--- a/MySQLInstaller/mysqlinstaller.h
+++ b/MySQLInstaller/mysqlinstaller.h
@@ -157,6 +157,16 @@ public:
     //  Stocke le mot de passe (clé Param_MDPSQL du rufus.ini).
     static void    stockerMotDePasse(const QString& mdp);
 
+    //  Sécurisation « à la volée » d'une base EXISTANTE connectée en monoposte.
+    //  Si .dbkey est absent (base encore sur le mot de passe public gaxt78iy), bascule
+    //  adminrufus/adminrufusSSL sur un mot de passe aléatoire en CONSERVANT gaxt78iy
+    //  comme 2e mot de passe (ALTER USER … RETAIN CURRENT PASSWORD) — pour ne bloquer
+    //  aucun autre poste si ce poste sert aussi de serveur —, puis écrit .dbkey.
+    //  No-op si : base déjà sécurisée (.dbkey présent), gaxt78iy inopérant, ou serveur
+    //  ne supportant pas le double mot de passe (MySQL < 8.0.14 / MariaDB).
+    //  À n'appeler qu'après une connexion MONOPOSTE réussie.
+    void    securiserBaseSiNecessaire();
+
     // Résultat de createUserAvecAdmin().
     enum class CreateUserResult { Ok, NoCreateUserRight, Error };
 


### PR DESCRIPTION
Connexion à une **base patients existante** en **monoposte** (`dlg_paramconnexion`, mode *Poste*) — gestion des deux cas avec le nouveau système de mot de passe.

**BS (base déjà sécurisée)** : `.dbkey` présent → `motDePasseSQL()` le lit → connexion avec le mot de passe aléatoire. *Inchangé.*

**BNS (ancienne base, pas de `.dbkey`)** : on se connecte via le repli `gaxt78iy`, puis le nouveau **`MySQLInstaller::securiserBaseSiNecessaire()`** sécurise la base **à la volée** :
- nouveau mot de passe **aléatoire** pour `adminrufus`/`adminrufusSSL` ;
- **`gaxt78iy` conservé comme 2ᵉ mot de passe** (`ALTER USER … RETAIN CURRENT PASSWORD`) → si ce poste sert aussi de **serveur réseau**, les autres postes (encore sur `gaxt78iy`) **ne sont pas bloqués** ;
- écriture du nouveau mot de passe dans `.dbkey`.

**Garde-fous** (no-op si) :
- `.dbkey` déjà présent (base sécurisée) ;
- `gaxt78iy` inopérant (base injoignable avec nos comptes) ;
- serveur ne supportant pas le double mot de passe — **MySQL < 8.0.14 / MariaDB** : rotater y bloquerait les autres postes, donc on s'abstient (sécurisation explicite plus tard).

Silencieux, transparent pour Maurice. **Monoposte uniquement** pour l'instant (le multi-poste viendra). Cas connu documenté : suppression manuelle de `.dbkey` sur une base déjà sécurisée (rare, à affiner).

Vérifié : `mysqlinstaller.cpp` compile (Qt6).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFVPrY9BEqWjvzkotspaXH)_