### PR TITLE
Installeurs : pré-contrôle du socle MySQL (≥ 8.0.14, MariaDB exclu) avant toute installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,19 +211,19 @@ jobs:
           qmake RufusQt6.pro CONFIG+=release "QMAKE_APPLE_DEVICE_ARCHS=x86_64 arm64"
           make -j"$(sysctl -n hw.ncpu)"
 
-      - name: Construire le dmg
+      - name: Construire le pkg (avec pré-contrôle MySQL)
         run: |
           set -e
-          chmod +x build_tools/macOS/create-rufus-dmg.sh
+          chmod +x build_tools/macOS/create-rufus-pkg.sh build_tools/macOS/preinstall
           APP=$(find . -maxdepth 3 -type d -name '*.app' | head -n1)
           echo "Bundle : $APP"
-          build_tools/macOS/create-rufus-dmg.sh "$APP" \
+          build_tools/macOS/create-rufus-pkg.sh "$APP" \
             '${{ needs.version.outputs.version }}' "$GITHUB_WORKSPACE"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Rufus-macOS-dmg
-          path: 'Rufus-*.dmg'
+          name: Rufus-macOS-pkg
+          path: 'Rufus-*.pkg'
 
   # ───────────────────────────────────────────────────────────────────────────
   #  Publication : uniquement sur tag « v* » → Release GitHub avec les 3 paquets.

--- a/build_tools/CI_RELEASES.md
+++ b/build_tools/CI_RELEASES.md
@@ -8,16 +8,43 @@ release :
 |---|---|---|
 | Windows | `Rufus-<version>-Setup.exe` | `windeployqt` + **Inno Setup** (`build_tools/Windows/RufusVision.iss`) |
 | Linux | `Rufus-<version>-x86_64.AppImage` (auto-installante) | `linuxdeployqt` + `appimagetool` + `build_tools/Linux/AppRun` |
-| macOS | `Rufus-<version>.dmg` (**universel x86_64 + arm64**) | `macdeployqt` + `build_tools/macOS/create-rufus-dmg.sh` |
+| macOS | `Rufus-<version>.pkg` (**universel x86_64 + arm64**) | `macdeployqt` + `pkgbuild` + `build_tools/macOS/create-rufus-pkg.sh` |
 
-> **macOS — binaire universel obligatoire.** On ne fait PAS l'impasse sur les Macs
-> Intel. Le job tourne sur `macos-14` (Apple Silicon, runners bien plus disponibles
-> que `macos-13`) mais compile en **universel** via
+> **macOS — `.pkg` (et non `.dmg`).** On utilise un **`.pkg`** parce qu'il permet un
+> script **`preinstall`** (`build_tools/macOS/preinstall`) qui **contrôle le socle
+> MySQL AVANT toute copie** (cf. § « Pré-contrôle MySQL »). Un glisser-déposer `.dmg`
+> n'a aucun hook pré-install. *(L'ancien `create-rufus-dmg.sh` est conservé mais
+> n'est plus utilisé par la CI.)*
+>
+> **Binaire universel obligatoire** (Macs Intel **et** Apple Silicon). Le job tourne
+> sur `macos-14` (runners plus disponibles) mais compile en **universel** via
 > `qmake … "QMAKE_APPLE_DEVICE_ARCHS=x86_64 arm64"` (Qt macOS officiel est universel ;
-> la tranche x86_64 est cross-compilée). Le `.dmg` obtenu tourne sur Intel **et**
-> Apple Silicon. **macOS est aussi le plus simple à produire à la main** (`macdeployqt`
-> + 2 lignes `codesign` via `CODESIGN_ID`, cf. `create-rufus-dmg.sh`) : si les runners
-> macOS de la CI font défaut, le faire localement n'a rien de pénalisant.
+> la tranche x86_64 est cross-compilée). Signature optionnelle : `CODESIGN_ID`
+> (Developer ID **Application** → l'app) et `CODESIGN_INSTALLER_ID` (Developer ID
+> **Installer** → le `.pkg`).
+
+## Pré-contrôle MySQL (avant installation)
+
+Avant de remplacer un Rufus existant, **chaque installeur vérifie le socle MySQL**
+(≥ **8.0.14**, MariaDB exclu) — pour ne **jamais** détruire une installation qui
+marche si le serveur est trop ancien :
+
+- **Windows** : section `[Code]` d'Inno Setup (`InitializeSetup` → `Abort` si KO) ;
+- **Linux** : dans `AppRun`, avant l'intégration/lancement (zenity) ;
+- **macOS** : script `preinstall` du `.pkg` (osascript via `launchctl asuser`).
+
+Logique commune (`mysqld --version` « brutal ») :
+- réponse **≥ 8.0.14** → on continue (serveur local OK, monoposte) ;
+- réponse **< 8.0.14 / MariaDB** → message de migration (sauvegarde → upgrade →
+  restauration) → **install annulée** ;
+- **pas de réponse** (pas de MySQL local : 1ʳᵉ install ou client réseau) → **3
+  boutons** (1ʳᵉ install / « serveur ≥ 8.0.14, je certifie » / « version inconnue →
+  vérifier »). Le choix + la date sont tracés dans **`~/.rufus/.certif`** (valeur
+  légale : l'utilisateur a *attesté*).
+
+> À rôder sur installeurs réels : valeurs de retour de `TaskDialogMsgBox` (Inno),
+> affichage `osascript` depuis un script pkg (`launchctl asuser`), et chemin
+> `~/.rufus` côté installeur élevé (Windows `{userprofile}`, macOS console-user).
 
 ## Version
 

--- a/build_tools/Linux/AppRun
+++ b/build_tools/Linux/AppRun
@@ -25,6 +25,72 @@ ICONS_DIR="${HOME}/.local/share/icons/hicolor/256x256/apps"
 BIN_DIR="${HOME}/.local/bin"
 DESKTOP="${APPS_DIR}/rufus.desktop"
 
+# ── Pré-contrôle du socle MySQL ──────────────────────────────────────────────
+#  Règle : MySQL >= 8.0.14, MariaDB exclu. Fait AVANT toute intégration/lancement,
+#  donc une AppImage incompatible ne s'installe pas. Trace dans ~/.rufus/.certif.
+RUFUS_DIR="${HOME}/.rufus"
+CERTIF="${RUFUS_DIR}/.certif"
+
+ecrit_certif() {
+    mkdir -p "${RUFUS_DIR}" 2>/dev/null
+    printf '%s | %s\n' "$(date '+%Y-%m-%d %H:%M')" "$1" >> "${CERTIF}" 2>/dev/null
+}
+
+# 0 = OK (>=8.0.14 MySQL) | 1 = trop vieux / MariaDB | 2 = pas de mysqld local
+controle_mysql_local() {
+    local out ver maj min pat
+    out="$(mysqld --version 2>/dev/null)" || return 2
+    [ -z "${out}" ] && return 2
+    printf '%s' "${out}" | grep -qi mariadb && return 1
+    ver="$(printf '%s' "${out}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
+    [ -z "${ver}" ] && return 2
+    maj="${ver%%.*}"; min="${ver#*.}"; min="${min%%.*}"; pat="${ver##*.}"
+    [ "${maj}" -gt 8 ] && return 0
+    [ "${maj}" -lt 8 ] && return 1
+    [ "${min}" -gt 0 ] && return 0
+    [ "${pat}" -ge 14 ] && return 0
+    return 1
+}
+
+# 0 = on peut continuer ; 1 = on bloque (socle non garanti)
+socle_mysql_ok() {
+    [ -z "${DISPLAY}${WAYLAND_DISPLAY}" ] && return 0   # pas de GUI → on n'interroge pas
+
+    controle_mysql_local; local e=$?
+
+    if [ "${e}" -eq 0 ]; then ecrit_certif "vérifié local : MySQL >= 8.0.14"; return 0; fi
+
+    if [ "${e}" -eq 1 ]; then
+        command -v zenity >/dev/null 2>&1 && zenity --error --no-wrap \
+          --title="MySQL trop ancien" \
+          --text="Cette version de Rufus exige MySQL 8.0.14 ou supérieur (MariaDB non pris en charge).\n\nVotre serveur MySQL local est trop ancien.\n\nAvant d'installer : sauvegardez votre base (ancien Rufus) → mettez MySQL à jour vers 8.x → restaurez, puis relancez." 2>/dev/null
+        ecrit_certif "REFUS : MySQL local < 8.0.14 ou MariaDB"
+        return 1
+    fi
+
+    # e = 2 : pas de mysqld local → 1re install OU client réseau
+    command -v zenity >/dev/null 2>&1 || { ecrit_certif "pas de mysqld local, zenity absent : laissé passer"; return 0; }
+    local out
+    out="$(zenity --question --no-wrap --title="Vérification du serveur MySQL" \
+        --text="Cette version de Rufus exige un serveur MySQL >= 8.0.14 (MariaDB non pris en charge).\n\nAucun MySQL local détecté. Quelle est votre situation ?" \
+        --ok-label="Première installation de Rufus" \
+        --extra-button="Serveur réseau >= 8.0.14 (je certifie)" \
+        --cancel-label="Version inconnue — vérifier d'abord" 2>/dev/null)"
+    if [ $? -eq 0 ]; then ecrit_certif "1re installation (pas de MySQL local)"; return 0; fi
+    if [ "${out}" = "Serveur réseau >= 8.0.14 (je certifie)" ]; then
+        ecrit_certif "CERTIFIÉ par l'utilisateur : serveur réseau >= 8.0.14"; return 0; fi
+    zenity --info --no-wrap --title="Vérifiez votre serveur" \
+        --text="Sur le SERVEUR, vérifiez la version de MySQL :\n  • mysqld --version\n  • ou, dans MySQL : SELECT VERSION();\nElle doit être >= 8.0.14 (et pas MariaDB).\n\nRelancez Rufus une fois la vérification faite." 2>/dev/null
+    ecrit_certif "ABANDON : version serveur inconnue, vérification demandée"
+    return 1
+}
+
+# On ne contrôle qu'à la « première » exécution (avant intégration au menu) : une
+# fois Rufus installé (.desktop présent), on ne ré-interroge plus à chaque lancement.
+if [ ! -f "${DESKTOP}" ] && [ -n "${APPIMAGE}" ]; then
+    socle_mysql_ok || exit 1
+fi
+
 integration_proposee() {
     # Déjà installé, ou demande explicite de ne rien faire, ou pas d'affichage
     # graphique (lancement en ligne de commande) → on ne propose rien.

--- a/build_tools/Windows/RufusVision.iss
+++ b/build_tools/Windows/RufusVision.iss
@@ -58,3 +58,130 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 
+
+; ─────────────────────────────────────────────────────────────────────────────
+;  PRÉ-CONTRÔLE MySQL (avant TOUTE installation : on ne touche pas à l'ancien
+;  Rufus tant que le socle MySQL n'est pas validé).
+;  Règle : MySQL >= 8.0.14 et PAS MariaDB. mysqld --version est « brutal » :
+;   • répond >= 8.0.14      -> serveur local OK (install/MAJ monoposte) -> on continue
+;   • répond < 8.0.14/Maria -> message de migration -> on ABANDONNE l'install
+;   • ne répond pas         -> pas de MySQL local : 1re install OU client réseau
+;                              -> 3 boutons (dont certification = trace légale .certif)
+; ─────────────────────────────────────────────────────────────────────────────
+[Code]
+const
+  MIN_MAJOR = 8; MIN_MINOR = 0; MIN_PATCH = 14;
+
+function LitSortie(const Cmd: String; var Output: String): Boolean;
+var TmpFile: String; Code: Integer; A: AnsiString;
+begin
+  Result := False; Output := '';
+  TmpFile := ExpandConstant('{tmp}\rufus_mysqld.txt');
+  if Exec(ExpandConstant('{cmd}'), '/C ' + Cmd + ' > "' + TmpFile + '" 2>&1', '',
+          SW_HIDE, ewWaitUntilTerminated, Code) then
+    if LoadStringFromFile(TmpFile, A) then begin Output := String(A); Result := True; end;
+  DeleteFile(TmpFile);
+end;
+
+// Extrait le 1er "entier.entier.entier" trouvé à partir de la position P.
+function ExtraitVersion(const S: String; var Maj, Min, Pat: Integer): Boolean;
+var i, n, val, champ: Integer; c: Char;
+begin
+  Result := False; Maj := 0; Min := 0; Pat := 0; champ := 0; val := 0; n := 0;
+  for i := 1 to Length(S) do begin
+    c := S[i];
+    if (c >= '0') and (c <= '9') then begin val := val*10 + (Ord(c)-Ord('0')); n := n+1; end
+    else if (c = '.') and (n > 0) then begin
+      if champ = 0 then Maj := val else if champ = 1 then Min := val;
+      champ := champ+1; val := 0; n := 0;
+      if champ > 2 then Break;
+    end else begin
+      if n > 0 then begin
+        if champ = 2 then begin Pat := val; Result := True; Exit; end;
+        // séquence d'entiers incomplète : on réinitialise
+        champ := 0; val := 0; n := 0;
+      end;
+    end;
+  end;
+  if (champ = 2) and (n > 0) then begin Pat := val; Result := True; end;
+end;
+
+// 0 = OK (>=8.0.14 MySQL) ; 1 = trop vieux/MariaDB ; 2 = pas de mysqld local
+function ControleMySQLLocal(): Integer;
+var Out: String; Maj, Min, Pat: Integer;
+begin
+  Result := 2;
+  if not LitSortie('mysqld --version', Out) then Exit;
+  if Trim(Out) = '' then Exit;
+  if Pos('mariadb', Lowercase(Out)) > 0 then begin Result := 1; Exit; end;
+  if not ExtraitVersion(Out, Maj, Min, Pat) then Exit;   // version illisible -> traiter comme absent
+  if (Maj > MIN_MAJOR)
+     or ((Maj = MIN_MAJOR) and (Min > MIN_MINOR))
+     or ((Maj = MIN_MAJOR) and (Min = MIN_MINOR) and (Pat >= MIN_PATCH)) then
+    Result := 0
+  else
+    Result := 1;
+end;
+
+procedure EcritCertif(const Ligne: String);
+var Dir: String;
+begin
+  Dir := ExpandConstant('{userprofile}\.rufus');
+  ForceDirectories(Dir);
+  SaveStringToFile(Dir + '\.certif',
+    GetDateTimeString('yyyy-mm-dd hh:nn', '-', ':') + ' | ' + Ligne + #13#10, True);
+end;
+
+// True = on continue l'installation ; False = on l'abandonne (ancien Rufus intact).
+function InitializeSetup(): Boolean;
+var etat, btn: Integer;
+begin
+  etat := ControleMySQLLocal();
+
+  if etat = 0 then begin
+    EcritCertif('vérifié local : MySQL >= 8.0.14');
+    Result := True; Exit;
+  end;
+
+  if etat = 1 then begin
+    MsgBox('Cette version de Rufus exige MySQL 8.0.14 ou supérieur, et n''est pas '
+      + 'compatible avec MariaDB.' + #13#10#13#10
+      + 'Votre serveur MySQL local est trop ancien (ou est MariaDB).' + #13#10#13#10
+      + 'Marche à suivre AVANT d''installer cette version :' + #13#10
+      + '  1. Ouvrez votre ancien Rufus et SAUVEGARDEZ votre base ;' + #13#10
+      + '  2. mettez MySQL à jour vers 8.4.9 (ou réinstallez proprement) ;' + #13#10
+      + '  3. restaurez votre sauvegarde, puis relancez cette installation.' + #13#10#13#10
+      + 'Installation annulée : votre version actuelle de Rufus n''a pas été modifiée.',
+      mbCriticalError, MB_OK);
+    EcritCertif('REFUS : MySQL local < 8.0.14 ou MariaDB');
+    Result := False; Exit;
+  end;
+
+  // etat = 2 : pas de MySQL local -> 1re install OU client réseau -> 3 boutons.
+  btn := TaskDialogMsgBox(
+    'Vérification de votre serveur MySQL',
+    'Cette version de Rufus exige un serveur MySQL 8.0.14 ou supérieur '
+      + '(MariaDB non pris en charge).' + #13#10#13#10
+      + 'Aucun MySQL n''a été détecté sur cet ordinateur. Indiquez votre situation :',
+    mbInformation, 0,
+    ['C''est normal : j''installe Rufus pour la PREMIÈRE fois',
+     'Ce poste se connecte à un SERVEUR réseau dont la version est >= 8.0.14 (je le certifie)',
+     'Connexion réseau, mais j''IGNORE la version du serveur'], 0);
+
+  case btn of
+    100: begin EcritCertif('1re installation (pas de MySQL local)'); Result := True; end;
+    101: begin EcritCertif('CERTIFIÉ par l''utilisateur : serveur réseau >= 8.0.14'); Result := True; end;
+  else
+    // 102 (version inconnue) ou fenêtre fermée : on guide et on ABANDONNE.
+    MsgBox('Avant d''installer cette version, vérifiez la version de MySQL sur votre '
+      + 'SERVEUR :' + #13#10
+      + '  • sur le serveur, ouvrez une invite de commandes et tapez : mysqld --version' + #13#10
+      + '  • ou dans MySQL Workbench : SELECT VERSION();' + #13#10#13#10
+      + 'Elle doit être >= 8.0.14 (et ne pas être MariaDB).' + #13#10#13#10
+      + 'Relancez cette installation une fois la vérification faite. '
+      + 'Votre version actuelle de Rufus n''a pas été modifiée.',
+      mbInformation, MB_OK);
+    EcritCertif('ABANDON : version serveur inconnue, vérification demandée');
+    Result := False;
+  end;
+end;

--- a/build_tools/macOS/create-rufus-pkg.sh
+++ b/build_tools/macOS/create-rufus-pkg.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────────
+#  Crée un .pkg d'installation de Rufus pour macOS à partir du bundle .app.
+#  Le .pkg (et non plus un .dmg glisser-déposer) permet un script « preinstall »
+#  qui CONTRÔLE le socle MySQL AVANT toute copie → on ne remplace pas l'ancien
+#  Rufus si MySQL est trop ancien (cf. build_tools/macOS/preinstall).
+#
+#  Usage :  ./create-rufus-pkg.sh  <chemin/vers/Rufus.app>  [version]  [dossier_sortie]
+#
+#  ⚠️ BINAIRE UNIVERSEL (x86_64 + arm64) — compiler en amont avec :
+#     qmake RufusQt6.pro CONFIG+=release "QMAKE_APPLE_DEVICE_ARCHS=x86_64 arm64"
+#  Vérif :  lipo -archs Rufus.app/Contents/MacOS/Rufus  →  « x86_64 arm64 ».
+#
+#  SIGNATURE (optionnelle) :
+#   • export CODESIGN_ID="Developer ID Application: …"  → signe l'app ;
+#   • export CODESIGN_INSTALLER_ID="Developer ID Installer: …"  → signe le .pkg.
+#  Sans elles, le .pkg n'est pas signé (Gatekeeper averti au 1er lancement).
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+APP_PATH="${1:?Usage: create-rufus-pkg.sh <Rufus.app> [version] [outdir]}"
+VERSION="${2:-dev}"
+OUTDIR="${3:-$(pwd)}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+echo "==> macdeployqt sur ${APP_PATH}"
+macdeployqt "${APP_PATH}" -verbose=1
+
+# Signature de l'app (en profondeur) si demandée.
+if [ -n "${CODESIGN_ID:-}" ]; then
+    echo "==> codesign app (${CODESIGN_ID})"
+    codesign --deep --force --options runtime --sign "${CODESIGN_ID}" "${APP_PATH}"
+fi
+
+# Mise en scène : un dossier racine ne contenant que l'app (→ /Applications).
+STAGE="$(mktemp -d)/root"
+SCRIPTS="$(mktemp -d)"
+mkdir -p "${STAGE}"
+cp -R "${APP_PATH}" "${STAGE}/"
+cp "${HERE}/preinstall" "${SCRIPTS}/preinstall"
+chmod +x "${SCRIPTS}/preinstall"
+
+PKG="${OUTDIR}/Rufus-${VERSION}.pkg"
+echo "==> pkgbuild ${PKG}"
+pkgbuild \
+    --root "${STAGE}" \
+    --scripts "${SCRIPTS}" \
+    --install-location /Applications \
+    --identifier org.rufusvision.rufus \
+    --version "${VERSION}" \
+    "${PKG}"
+
+# Signature du .pkg (certificat « Developer ID Installer ») si demandée.
+if [ -n "${CODESIGN_INSTALLER_ID:-}" ]; then
+    echo "==> productsign (${CODESIGN_INSTALLER_ID})"
+    SIGNED="${OUTDIR}/Rufus-${VERSION}-signed.pkg"
+    productsign --sign "${CODESIGN_INSTALLER_ID}" "${PKG}" "${SIGNED}"
+    mv -f "${SIGNED}" "${PKG}"
+fi
+
+echo "==> OK : ${PKG}"

--- a/build_tools/macOS/preinstall
+++ b/build_tools/macOS/preinstall
@@ -1,0 +1,86 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────────
+#  preinstall du .pkg Rufus — PRÉ-CONTRÔLE du socle MySQL, AVANT toute copie.
+#  Un exit ≠ 0 annule l'installation → l'ancien Rufus n'est PAS remplacé.
+#  Règle : MySQL >= 8.0.14, MariaDB exclu. Trace dans ~/.rufus/.certif.
+#
+#  Particularité macOS : le script tourne en root dans le contexte de l'installeur
+#  (sans session graphique). On affiche les dialogues dans la session de
+#  l'utilisateur connecté via « launchctl asuser … osascript ».
+# ─────────────────────────────────────────────────────────────────────────────
+MIN_MAJOR=8; MIN_MINOR=0; MIN_PATCH=14
+
+CONSOLE_UID="$(stat -f%Su /dev/console 2>/dev/null)"
+CONSOLE_HOME="$(eval echo "~${CONSOLE_UID}" 2>/dev/null)"
+
+osa() {   # osascript dans la session de l'utilisateur connecté
+    launchctl asuser "$(id -u "${CONSOLE_UID}" 2>/dev/null)" osascript "$@" 2>/dev/null
+}
+
+ecrit_certif() {
+    local dir="${CONSOLE_HOME}/.rufus"
+    mkdir -p "${dir}" 2>/dev/null
+    printf '%s | %s\n' "$(date '+%Y-%m-%d %H:%M')" "$1" >> "${dir}/.certif" 2>/dev/null
+    chown -R "${CONSOLE_UID}" "${dir}" 2>/dev/null
+}
+
+# 0 = OK (>=8.0.14 MySQL) | 1 = trop vieux / MariaDB | 2 = pas de mysqld local
+controle_mysql_local() {
+    local bin="" c out ver maj min pat
+    for c in mysqld /usr/local/mysql/bin/mysqld; do
+        if command -v "$c" >/dev/null 2>&1; then bin="$c"; break; fi
+        if [ -x "$c" ]; then bin="$c"; break; fi
+    done
+    [ -z "${bin}" ] && return 2
+    out="$("${bin}" --version 2>/dev/null)" || return 2
+    [ -z "${out}" ] && return 2
+    printf '%s' "${out}" | grep -qi mariadb && return 1
+    ver="$(printf '%s' "${out}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
+    [ -z "${ver}" ] && return 2
+    maj="${ver%%.*}"; min="${ver#*.}"; min="${min%%.*}"; pat="${ver##*.}"
+    [ "${maj}" -gt 8 ] && return 0
+    [ "${maj}" -lt 8 ] && return 1
+    [ "${min}" -gt 0 ] && return 0
+    [ "${pat}" -ge 14 ] && return 0
+    return 1
+}
+
+controle_mysql_local; ETAT=$?
+
+if [ "${ETAT}" -eq 0 ]; then
+    ecrit_certif "vérifié local : MySQL >= 8.0.14"
+    exit 0
+fi
+
+if [ "${ETAT}" -eq 1 ]; then
+    osa -e 'display dialog "Cette version de Rufus exige MySQL 8.0.14 ou supérieur (MariaDB non pris en charge).
+
+Votre serveur MySQL local est trop ancien.
+
+Avant d'\''installer : sauvegardez votre base (ancien Rufus) → mettez MySQL à jour vers 8.4.9 → restaurez, puis relancez cette installation." buttons {"Annuler l'\''installation"} default button 1 with title "MySQL trop ancien" with icon stop'
+    ecrit_certif "REFUS : MySQL local < 8.0.14 ou MariaDB"
+    exit 1
+fi
+
+# ETAT = 2 : pas de mysqld local → 1re install OU client réseau → 3 boutons
+CHOIX="$(osa -e 'try' \
+  -e 'set b to button returned of (display dialog "Cette version de Rufus exige un serveur MySQL >= 8.0.14 (MariaDB non pris en charge).
+
+Aucun MySQL local détecté. Quelle est votre situation ?" buttons {"Version inconnue", "Première installation", "Serveur >= 8.0.14"} default button 2 with title "Vérification du serveur MySQL")' \
+  -e 'return b' -e 'on error' -e 'return "CANCEL"' -e 'end try')"
+
+case "${CHOIX}" in
+  "Première installation")
+      ecrit_certif "1re installation (pas de MySQL local)"; exit 0 ;;
+  "Serveur >= 8.0.14")
+      ecrit_certif "CERTIFIÉ par l'utilisateur : serveur réseau >= 8.0.14"; exit 0 ;;
+  *)
+      osa -e 'display dialog "Sur le SERVEUR, vérifiez la version de MySQL :
+  •  mysqld --version
+  •  ou, dans MySQL : SELECT VERSION();
+Elle doit être >= 8.0.14 (et pas MariaDB).
+
+Relancez cette installation une fois la vérification faite. Votre version actuelle de Rufus n'\''a pas été modifiée." buttons {"OK"} default button 1 with title "Vérifiez votre serveur"'
+      ecrit_certif "ABANDON : version serveur inconnue, vérification demandée"
+      exit 1 ;;
+esac


### PR DESCRIPTION
Le **socle MySQL ≥ 8.0.14 (MariaDB exclu)** est vérifié **par l'installeur système, AVANT toute copie** — donc on ne détruit **jamais** un Rufus qui marche si le serveur est trop ancien. Le Maurice qui a sauté de nombreuses versions est traité comme les autres (aucune dépendance à un historique de mises à jour).

## Logique commune (`mysqld --version` « brutal »)
- **≥ 8.0.14** → serveur local OK (install/MAJ monoposte) → on continue ;
- **< 8.0.14 / MariaDB** → message de migration (sauvegarde → upgrade → restauration) → **installation annulée** ;
- **pas de réponse** (pas de MySQL local : 1ʳᵉ install **ou** client réseau) → **3 boutons** :
  1. « Première installation de Rufus » → on continue ;
  2. « Serveur réseau ≥ 8.0.14 (je certifie) » → on continue ;
  3. « Version inconnue → vérifier » → instructions + **abandon**.

Choix + date tracés dans **`~/.rufus/.certif`** (valeur **légale** : l'utilisateur a *attesté*), **pas** dans `rufus.ini` (dont l'absence/présence distingue 1ʳᵉ install vs MAJ).

## Implémentations (3 technologies d'installeur)
- **Windows** : section `[Code]` d'Inno Setup (`InitializeSetup` → `Abort` si KO) ;
- **Linux** : dans `AppRun`, avant l'intégration/lancement (zenity), **une seule fois** (plus de question aux lancements suivants) ;
- **macOS** : **passage du `.dmg` au `.pkg`** (script `preinstall` + `osascript` via `launchctl asuser`) → **modifie le job macOS de la CI** (artefact `Rufus-*.pkg`, toujours universel x86_64 + arm64).

## À rôder sur installeurs réels
Non testable ici (pas d'Inno/macOS/install) : valeurs de retour de `TaskDialogMsgBox`, affichage `osascript` depuis un script pkg, chemin `~/.rufus` côté installeur élevé. YAML + bash vérifiés.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFVPrY9BEqWjvzkotspaXH)_