### PR TITLE
Installeurs : contrôle MySQL uniquement en MAJ (pas en install neuve), bouton « 1re install » retiré

### DIFF
--- a/build_tools/CI_RELEASES.md
+++ b/build_tools/CI_RELEASES.md
@@ -25,9 +25,13 @@ release :
 
 ## Pré-contrôle MySQL (avant installation)
 
-Avant de remplacer un Rufus existant, **chaque installeur vérifie le socle MySQL**
-(≥ **8.0.14**, MariaDB exclu) — pour ne **jamais** détruire une installation qui
-marche si le serveur est trop ancien :
+Le contrôle ne se fait **QU'EN cas de MISE À JOUR** d'un Rufus préexistant : en
+**installation neuve, il n'y a rien à détruire** → aucun contrôle, aucune question.
+Chaque installeur détecte d'abord un Rufus déjà présent (Windows : clé de
+désinstallation / `Rufus.exe` ; Linux : raccourci/AppImage installée / `rufus.ini` ;
+macOS : `/Applications/Rufus*.app`). S'il y en a un, il **vérifie le socle MySQL**
+(≥ **8.0.14**, MariaDB exclu) pour ne **jamais** détruire une installation qui marche
+si le serveur est trop ancien :
 
 - **Windows** : section `[Code]` d'Inno Setup (`InitializeSetup` → `Abort` si KO) ;
 - **Linux** : dans `AppRun`, avant l'intégration/lancement (zenity) ;
@@ -36,11 +40,11 @@ marche si le serveur est trop ancien :
 Logique commune (`mysqld --version` « brutal ») :
 - réponse **≥ 8.0.14** → on continue (serveur local OK, monoposte) ;
 - réponse **< 8.0.14 / MariaDB** → message de migration (sauvegarde → upgrade →
-  restauration) → **install annulée** ;
-- **pas de réponse** (pas de MySQL local : 1ʳᵉ install ou client réseau) → **3
-  boutons** (1ʳᵉ install / « serveur ≥ 8.0.14, je certifie » / « version inconnue →
-  vérifier »). Le choix + la date sont tracés dans **`~/.rufus/.certif`** (valeur
-  légale : l'utilisateur a *attesté*).
+  restauration) → **mise à jour annulée** ;
+- **pas de réponse** (pas de MySQL local → le Rufus existant est un client réseau) →
+  **2 boutons** (« serveur ≥ 8.0.14, je certifie » / « version inconnue → vérifier »).
+  Le choix + la date sont tracés dans **`~/.rufus/.certif`** (valeur légale :
+  l'utilisateur a *attesté*).
 
 > À rôder sur installeurs réels : valeurs de retour de `TaskDialogMsgBox` (Inno),
 > affichage `osascript` depuis un script pkg (`launchctl asuser`), et chemin

--- a/build_tools/Linux/AppRun
+++ b/build_tools/Linux/AppRun
@@ -25,15 +25,23 @@ ICONS_DIR="${HOME}/.local/share/icons/hicolor/256x256/apps"
 BIN_DIR="${HOME}/.local/bin"
 DESKTOP="${APPS_DIR}/rufus.desktop"
 
-# ── Pré-contrôle du socle MySQL ──────────────────────────────────────────────
-#  Règle : MySQL >= 8.0.14, MariaDB exclu. Fait AVANT toute intégration/lancement,
-#  donc une AppImage incompatible ne s'installe pas. Trace dans ~/.rufus/.certif.
+# ── Pré-contrôle du socle MySQL (UNIQUEMENT en cas de MISE À JOUR) ────────────
+#  Règle : MySQL >= 8.0.14, MariaDB exclu. On ne contrôle que si un Rufus PRÉEXISTE
+#  (sinon, install neuve = rien à détruire = pas de contrôle). Trace ~/.rufus/.certif.
 RUFUS_DIR="${HOME}/.rufus"
 CERTIF="${RUFUS_DIR}/.certif"
+INSTALLED_APPIMAGE="${BIN_DIR}/${APPNAME}.AppImage"
 
 ecrit_certif() {
     mkdir -p "${RUFUS_DIR}" 2>/dev/null
     printf '%s | %s\n' "$(date '+%Y-%m-%d %H:%M')" "$1" >> "${CERTIF}" 2>/dev/null
+}
+
+# Un Rufus est-il déjà installé/utilisé ici ? (raccourci menu, AppImage installée,
+# ou config rufus.ini d'une utilisation antérieure)
+rufus_preexistant() {
+    [ -f "${DESKTOP}" ] || [ -f "${INSTALLED_APPIMAGE}" ] \
+        || [ -f "${HOME}/Documents/Rufus/rufus.ini" ]
 }
 
 # 0 = OK (>=8.0.14 MySQL) | 1 = trop vieux / MariaDB | 2 = pas de mysqld local
@@ -58,36 +66,36 @@ socle_mysql_ok() {
 
     controle_mysql_local; local e=$?
 
-    if [ "${e}" -eq 0 ]; then ecrit_certif "vérifié local : MySQL >= 8.0.14"; return 0; fi
+    if [ "${e}" -eq 0 ]; then ecrit_certif "MAJ - vérifié local : MySQL >= 8.0.14"; return 0; fi
 
     if [ "${e}" -eq 1 ]; then
         command -v zenity >/dev/null 2>&1 && zenity --error --no-wrap \
           --title="MySQL trop ancien" \
-          --text="Cette version de Rufus exige MySQL 8.0.14 ou supérieur (MariaDB non pris en charge).\n\nVotre serveur MySQL local est trop ancien.\n\nAvant d'installer : sauvegardez votre base (ancien Rufus) → mettez MySQL à jour vers 8.x → restaurez, puis relancez." 2>/dev/null
-        ecrit_certif "REFUS : MySQL local < 8.0.14 ou MariaDB"
+          --text="Cette version de Rufus exige MySQL 8.0.14 ou supérieur (MariaDB non pris en charge).\n\nVotre serveur MySQL local est trop ancien.\n\nAvant de mettre à jour : sauvegardez votre base (Rufus actuel) → mettez MySQL à jour vers 8.x → restaurez, puis relancez." 2>/dev/null
+        ecrit_certif "REFUS (MAJ) : MySQL local < 8.0.14 ou MariaDB"
         return 1
     fi
 
-    # e = 2 : pas de mysqld local → 1re install OU client réseau
+    # e = 2 : pas de mysqld local → le Rufus existant est un CLIENT réseau → 2 boutons
     command -v zenity >/dev/null 2>&1 || { ecrit_certif "pas de mysqld local, zenity absent : laissé passer"; return 0; }
-    local out
-    out="$(zenity --question --no-wrap --title="Vérification du serveur MySQL" \
-        --text="Cette version de Rufus exige un serveur MySQL >= 8.0.14 (MariaDB non pris en charge).\n\nAucun MySQL local détecté. Quelle est votre situation ?" \
-        --ok-label="Première installation de Rufus" \
-        --extra-button="Serveur réseau >= 8.0.14 (je certifie)" \
-        --cancel-label="Version inconnue — vérifier d'abord" 2>/dev/null)"
-    if [ $? -eq 0 ]; then ecrit_certif "1re installation (pas de MySQL local)"; return 0; fi
-    if [ "${out}" = "Serveur réseau >= 8.0.14 (je certifie)" ]; then
-        ecrit_certif "CERTIFIÉ par l'utilisateur : serveur réseau >= 8.0.14"; return 0; fi
+    if zenity --question --no-wrap --title="Vérification du serveur MySQL" \
+        --text="Cette version de Rufus exige un serveur MySQL >= 8.0.14 (MariaDB non pris en charge).\n\nAucun MySQL local détecté (ce poste se connecte donc à un serveur réseau)." \
+        --ok-label="Le serveur est en >= 8.0.14 (je certifie)" \
+        --cancel-label="J'ignore la version — vérifier d'abord" 2>/dev/null; then
+        ecrit_certif "CERTIFIÉ par l'utilisateur (MAJ) : serveur réseau >= 8.0.14"
+        return 0
+    fi
     zenity --info --no-wrap --title="Vérifiez votre serveur" \
         --text="Sur le SERVEUR, vérifiez la version de MySQL :\n  • mysqld --version\n  • ou, dans MySQL : SELECT VERSION();\nElle doit être >= 8.0.14 (et pas MariaDB).\n\nRelancez Rufus une fois la vérification faite." 2>/dev/null
-    ecrit_certif "ABANDON : version serveur inconnue, vérification demandée"
+    ecrit_certif "ABANDON (MAJ) : version serveur inconnue, vérification demandée"
     return 1
 }
 
-# On ne contrôle qu'à la « première » exécution (avant intégration au menu) : une
-# fois Rufus installé (.desktop présent), on ne ré-interroge plus à chaque lancement.
-if [ ! -f "${DESKTOP}" ] && [ -n "${APPIMAGE}" ]; then
+# On ne contrôle qu'en cas de MISE À JOUR : un Rufus préexiste ET on lance une
+# AppImage AUTRE que celle déjà installée (= une nouvelle version qu'on démarre).
+# Lancement normal depuis le menu (AppImage installée) → pas de contrôle, pas de
+# question. Installation neuve (aucun Rufus préexistant) → pas de contrôle non plus.
+if [ -n "${APPIMAGE}" ] && [ "${APPIMAGE}" != "${INSTALLED_APPIMAGE}" ] && rufus_preexistant; then
     socle_mysql_ok || exit 1
 fi
 

--- a/build_tools/Windows/RufusVision.iss
+++ b/build_tools/Windows/RufusVision.iss
@@ -132,14 +132,32 @@ begin
     GetDateTimeString('yyyy-mm-dd hh:nn', '-', ':') + ' | ' + Ligne + #13#10, True);
 end;
 
+// Un Rufus est-il DÉJÀ installé sur ce poste ? (clé de désinstallation Inno de notre
+// AppId, ou Rufus.exe à l'emplacement par défaut). Le contrôle MySQL ne se fait QU'EN
+// cas de MAJ : en installation neuve il n'y a rien à détruire, donc rien à vérifier.
+function RufusDejaInstalle(): Boolean;
+const KEY = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{BB737C7D-1DA8-4BB2-9950-DA8781E50453}_is1';
+begin
+  Result := FileExists(ExpandConstant('{autopf}\{#MyAppName}\{#MyAppExeName}'))
+         or RegKeyExists(HKLM64, KEY) or RegKeyExists(HKLM32, KEY)
+         or RegKeyExists(HKCU64, KEY) or RegKeyExists(HKCU32, KEY);
+end;
+
 // True = on continue l'installation ; False = on l'abandonne (ancien Rufus intact).
 function InitializeSetup(): Boolean;
 var etat, btn: Integer;
 begin
+  // Installation NEUVE (aucun Rufus préexistant) : rien à détruire → on n'importune
+  // pas l'utilisateur, on installe directement.
+  if not RufusDejaInstalle() then begin
+    Result := True; Exit;
+  end;
+
+  // MISE À JOUR d'un Rufus existant : on protège l'installation qui marche.
   etat := ControleMySQLLocal();
 
   if etat = 0 then begin
-    EcritCertif('vérifié local : MySQL >= 8.0.14');
+    EcritCertif('MAJ - vérifié local : MySQL >= 8.0.14');
     Result := True; Exit;
   end;
 
@@ -147,41 +165,40 @@ begin
     MsgBox('Cette version de Rufus exige MySQL 8.0.14 ou supérieur, et n''est pas '
       + 'compatible avec MariaDB.' + #13#10#13#10
       + 'Votre serveur MySQL local est trop ancien (ou est MariaDB).' + #13#10#13#10
-      + 'Marche à suivre AVANT d''installer cette version :' + #13#10
-      + '  1. Ouvrez votre ancien Rufus et SAUVEGARDEZ votre base ;' + #13#10
+      + 'Marche à suivre AVANT de mettre à jour :' + #13#10
+      + '  1. Ouvrez votre Rufus actuel et SAUVEGARDEZ votre base ;' + #13#10
       + '  2. mettez MySQL à jour vers 8.4.9 (ou réinstallez proprement) ;' + #13#10
-      + '  3. restaurez votre sauvegarde, puis relancez cette installation.' + #13#10#13#10
-      + 'Installation annulée : votre version actuelle de Rufus n''a pas été modifiée.',
+      + '  3. restaurez votre sauvegarde, puis relancez cette mise à jour.' + #13#10#13#10
+      + 'Mise à jour annulée : votre version actuelle de Rufus n''a pas été modifiée.',
       mbCriticalError, MB_OK);
-    EcritCertif('REFUS : MySQL local < 8.0.14 ou MariaDB');
+    EcritCertif('REFUS (MAJ) : MySQL local < 8.0.14 ou MariaDB');
     Result := False; Exit;
   end;
 
-  // etat = 2 : pas de MySQL local -> 1re install OU client réseau -> 3 boutons.
+  // etat = 2 : pas de MySQL local → le Rufus existant est un CLIENT réseau → 2 boutons.
   btn := TaskDialogMsgBox(
     'Vérification de votre serveur MySQL',
     'Cette version de Rufus exige un serveur MySQL 8.0.14 ou supérieur '
       + '(MariaDB non pris en charge).' + #13#10#13#10
-      + 'Aucun MySQL n''a été détecté sur cet ordinateur. Indiquez votre situation :',
+      + 'Aucun MySQL n''a été détecté sur cet ordinateur (ce poste se connecte donc à '
+      + 'un serveur réseau). Indiquez votre situation :',
     mbInformation, 0,
-    ['C''est normal : j''installe Rufus pour la PREMIÈRE fois',
-     'Ce poste se connecte à un SERVEUR réseau dont la version est >= 8.0.14 (je le certifie)',
-     'Connexion réseau, mais j''IGNORE la version du serveur'], 0);
+    ['Le serveur réseau est en version >= 8.0.14 (je le certifie)',
+     'J''IGNORE la version du serveur'], 0);
 
-  case btn of
-    100: begin EcritCertif('1re installation (pas de MySQL local)'); Result := True; end;
-    101: begin EcritCertif('CERTIFIÉ par l''utilisateur : serveur réseau >= 8.0.14'); Result := True; end;
-  else
-    // 102 (version inconnue) ou fenêtre fermée : on guide et on ABANDONNE.
-    MsgBox('Avant d''installer cette version, vérifiez la version de MySQL sur votre '
-      + 'SERVEUR :' + #13#10
+  if btn = 100 then begin
+    EcritCertif('CERTIFIÉ par l''utilisateur (MAJ) : serveur réseau >= 8.0.14');
+    Result := True;
+  end else begin
+    // 101 (version inconnue) ou fenêtre fermée : on guide et on ABANDONNE.
+    MsgBox('Avant de mettre à jour, vérifiez la version de MySQL sur votre SERVEUR :' + #13#10
       + '  • sur le serveur, ouvrez une invite de commandes et tapez : mysqld --version' + #13#10
       + '  • ou dans MySQL Workbench : SELECT VERSION();' + #13#10#13#10
       + 'Elle doit être >= 8.0.14 (et ne pas être MariaDB).' + #13#10#13#10
-      + 'Relancez cette installation une fois la vérification faite. '
+      + 'Relancez cette mise à jour une fois la vérification faite. '
       + 'Votre version actuelle de Rufus n''a pas été modifiée.',
       mbInformation, MB_OK);
-    EcritCertif('ABANDON : version serveur inconnue, vérification demandée');
+    EcritCertif('ABANDON (MAJ) : version serveur inconnue, vérification demandée');
     Result := False;
   end;
 end;

--- a/build_tools/macOS/preinstall
+++ b/build_tools/macOS/preinstall
@@ -45,10 +45,14 @@ controle_mysql_local() {
     return 1
 }
 
+# Le contrôle ne se fait QU'EN cas de MISE À JOUR : si aucun Rufus n'est déjà présent
+# dans /Applications, c'est une installation NEUVE → rien à détruire → on installe.
+ls -d /Applications/Rufus*.app >/dev/null 2>&1 || exit 0
+
 controle_mysql_local; ETAT=$?
 
 if [ "${ETAT}" -eq 0 ]; then
-    ecrit_certif "vérifié local : MySQL >= 8.0.14"
+    ecrit_certif "MAJ - vérifié local : MySQL >= 8.0.14"
     exit 0
 fi
 
@@ -57,30 +61,28 @@ if [ "${ETAT}" -eq 1 ]; then
 
 Votre serveur MySQL local est trop ancien.
 
-Avant d'\''installer : sauvegardez votre base (ancien Rufus) → mettez MySQL à jour vers 8.4.9 → restaurez, puis relancez cette installation." buttons {"Annuler l'\''installation"} default button 1 with title "MySQL trop ancien" with icon stop'
-    ecrit_certif "REFUS : MySQL local < 8.0.14 ou MariaDB"
+Avant de mettre à jour : sauvegardez votre base (Rufus actuel) → mettez MySQL à jour vers 8.4.9 → restaurez, puis relancez cette mise à jour." buttons {"Annuler la mise à jour"} default button 1 with title "MySQL trop ancien" with icon stop'
+    ecrit_certif "REFUS (MAJ) : MySQL local < 8.0.14 ou MariaDB"
     exit 1
 fi
 
-# ETAT = 2 : pas de mysqld local → 1re install OU client réseau → 3 boutons
+# ETAT = 2 : pas de mysqld local → le Rufus existant est un CLIENT réseau → 2 boutons
 CHOIX="$(osa -e 'try' \
   -e 'set b to button returned of (display dialog "Cette version de Rufus exige un serveur MySQL >= 8.0.14 (MariaDB non pris en charge).
 
-Aucun MySQL local détecté. Quelle est votre situation ?" buttons {"Version inconnue", "Première installation", "Serveur >= 8.0.14"} default button 2 with title "Vérification du serveur MySQL")' \
+Aucun MySQL local détecté (ce poste se connecte à un serveur réseau). Quelle est votre situation ?" buttons {"Version inconnue", "Serveur >= 8.0.14"} default button 2 with title "Vérification du serveur MySQL")' \
   -e 'return b' -e 'on error' -e 'return "CANCEL"' -e 'end try')"
 
 case "${CHOIX}" in
-  "Première installation")
-      ecrit_certif "1re installation (pas de MySQL local)"; exit 0 ;;
   "Serveur >= 8.0.14")
-      ecrit_certif "CERTIFIÉ par l'utilisateur : serveur réseau >= 8.0.14"; exit 0 ;;
+      ecrit_certif "CERTIFIÉ par l'utilisateur (MAJ) : serveur réseau >= 8.0.14"; exit 0 ;;
   *)
       osa -e 'display dialog "Sur le SERVEUR, vérifiez la version de MySQL :
   •  mysqld --version
   •  ou, dans MySQL : SELECT VERSION();
 Elle doit être >= 8.0.14 (et pas MariaDB).
 
-Relancez cette installation une fois la vérification faite. Votre version actuelle de Rufus n'\''a pas été modifiée." buttons {"OK"} default button 1 with title "Vérifiez votre serveur"'
-      ecrit_certif "ABANDON : version serveur inconnue, vérification demandée"
+Relancez cette mise à jour une fois la vérification faite. Votre version actuelle de Rufus n'\''a pas été modifiée." buttons {"OK"} default button 1 with title "Vérifiez votre serveur"'
+      ecrit_certif "ABANDON (MAJ) : version serveur inconnue, vérification demandée"
       exit 1 ;;
 esac


### PR DESCRIPTION
Simplification : le pré-contrôle MySQL ne sert qu'à **protéger un Rufus existant lors d'une mise à jour**. En **installation neuve, rien à détruire** → plus aucun contrôle ni question. Le bouton « première installation » disparaît (il ne reste que **2 boutons** dans le cas client réseau).

## Détection d'un Rufus préexistant (sinon : install neuve → on installe direct)
- **Windows** : clé de désinstallation Inno (HKLM/HKCU, vues 32 & 64 bits) ou `Rufus.exe` à l'emplacement par défaut ;
- **Linux** : raccourci menu / AppImage installée / `~/Documents/Rufus/rufus.ini` — **et** on ne contrôle que si l'on lance une AppImage **autre** que celle déjà installée (lancement normal depuis le menu = aucune question) ;
- **macOS** : présence de `/Applications/Rufus*.app` (le `preinstall` sort tôt sinon).

## En cas de MAJ
`mysqld --version` → ≥ 8.0.14 : on continue · < 8.0.14 / MariaDB : message migration + **MAJ annulée** · pas de mysqld local (= client réseau) → **2 boutons** : « serveur ≥ 8.0.14, je certifie » ou « version inconnue → vérifier » (abandon). Trace `~/.rufus/.certif`.

bash + (logique Inno) relus ; à rôder sur installeurs réels comme convenu.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFVPrY9BEqWjvzkotspaXH)_